### PR TITLE
Include models path in azure pipeline trigger

### DIFF
--- a/src/commands/azure-pipeline/libs/trigger/trigger.ts
+++ b/src/commands/azure-pipeline/libs/trigger/trigger.ts
@@ -51,7 +51,7 @@ function findLib(dir: string) {
 
       if (libName === 'database') {
         if (splitLibPath.length > 2) {
-          libName = `${splitLibPath[1]}/src/${splitLibPath[2]}/${splitLibPath[3]}`;
+          libName = `${splitLibPath[1]}/src/${splitLibPath[2]}/${splitLibPath[3]}/models`;
         } else {
           return;
         }


### PR DESCRIPTION
- Modify "trigger.ts" to add "models" to the library name for the database